### PR TITLE
Version 0.0.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 GOMV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Para instalar govm, simplemente clona este repositorio y compila el proyecto:
 ```sh
 git clone https://github.com/tu_usuario/govm.git
 cd govm
-go build
+go build -o govm
 ```
 
 ## Uso
@@ -27,6 +27,13 @@ Lista todas las versiones de Go instaladas en tu sistema:
 
 ```sh
 govm list
+```
+
+### Crear carpeta contenedora de versiones
+Crea una carpeta `.govm/versions` en `/home`
+
+```sh
+govm config
 ```
 
 ### Usar una versión específica

--- a/colors/colors.go
+++ b/colors/colors.go
@@ -1,0 +1,50 @@
+// Copyright © 2024 GOMV
+// Licensed under the MIT License. See LICENSE file for details.
+
+package colors
+
+import (
+	"github.com/fatih/color"
+)
+
+func makeMapColor() map[string]color.Attribute {
+	// Este mapa asocia nombres de colores con sus codigos correspondientes.
+
+	// Los colores se representan mediante valores enteros definidos en el paquete `color`.
+	// Por ejemplo:
+	// - Codigo para rojo: 31 (color.FgRed)
+	// - Codigo para verde: 32 (color.FgGreen)
+
+	// Cada entrada en el mapa utiliza la constante `color.Attribute`, que es el tipo manejado
+	// por el paquete `color` para definir colores de texto.
+
+	mapColor := map[string]color.Attribute{
+		"red":   color.FgRed,
+		"green": color.FgGreen,
+	}
+
+	return mapColor
+}
+
+func SetColor(c color.Attribute, format string, a ...interface{}) {
+	// SetColor aplica un color especifico al texto y lo imprime.
+	// Utiliza el mapa generado por `makeMapColor` para obtener los atributos de color.
+	//
+	// Args:
+	//   [1] c: color.Attribute, el atributo de color, por el paquete color.
+	//   [2] format: Cadena de texto que queremos imprimir.
+	//   [3] a: Argumentos adicionales, se pueden pasar para formatear el texto.
+	//
+	// Ejemplo:
+	//   SetColor(color.FgRed, "Error: %v", err)
+
+	mapC := makeMapColor()
+	switch c {
+	case 31:
+		red := color.New(mapC["red"]).PrintfFunc()
+		red(format, a...)
+	case 32:
+		green := color.New(mapC["green"]).PrintfFunc()
+		green(format, a...)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module gomv
 
 go 1.23.2
+
+require (
+	github.com/fatih/color v1.18.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	golang.org/x/sys v0.25.0 // indirect
+)

--- a/main.go
+++ b/main.go
@@ -1,18 +1,24 @@
+// Copyright © 2024 GOMV
+// Licensed under the MIT License. See LICENSE file for details.
+
 package main
 
 import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"gomv/colors"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/fatih/color"
 )
 
 var versionsDir = filepath.Join(os.Getenv("HOME"), ".govm", "versions") // Cambia a tu ruta de versiones
 const goBinDir = "/usr/local/go/bin"                                    // Ruta donde deben copiarse los archivos binarios
-const Version string = "0.0.1"
+const Version string = "0.0.2"
 
 // Función para asegurar que un directorio existe, creándolo si es necesario
 func ensureDirExists(dir string) error {
@@ -27,12 +33,16 @@ func ensureDirExists(dir string) error {
 
 // Función para listar versiones instaladas
 func listVersions() {
-	fmt.Println("Listing installed Go versions...")
 	files, err := os.ReadDir(versionsDir)
 	if err != nil {
 		fmt.Println("Error reading versions:", err)
 		return
 	}
+	if len(files) == 0 {
+		fmt.Printf("Empty folder %s\n", versionsDir)
+		return
+	}
+	fmt.Println("Listing installed Go versions...")
 	for _, file := range files {
 		fmt.Println(file.Name())
 	}
@@ -215,28 +225,20 @@ func uninstallVersion(version string) {
 }
 
 func helpUser() {
-	fmt.Println(`
-Use: govm <command> [version]
-
-help
-	Get help ready and end with a successful exit
-
-list
-	List installed versions of go	
-use
-	use the specific version of go, if installed
-install
-	Install the specified version of go
-uninstall
-	uninstall the specific version of go
-version
-	Displays the version and exits successfully`)
+	colors.SetColor(color.FgGreen, "Use: govm <command> [version]\n")
+	colors.SetColor(color.FgGreen, "help \n\t Get help ready and end with a successful exit\n")
+	colors.SetColor(color.FgGreen, "config \n\t Create the folder in the home path\n")
+	colors.SetColor(color.FgGreen, "list \n\t List installed versions of go\n")
+	colors.SetColor(color.FgGreen, "use \n\t use the specific version of go, if installed\n")
+	colors.SetColor(color.FgGreen, "install \n\t Install the specified version of go\n")
+	colors.SetColor(color.FgGreen, "uninstall \n\t uninstall the specific version of go\n")
+	colors.SetColor(color.FgGreen, "version \n\t Displays the version and exits successfully\n")
 	os.Exit(0)
 }
 
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: govm <command> [version] or <help> to more info")
+		colors.SetColor(32, "Usage: govm <command> [version] or <help> to more info\n")
 		return
 	}
 
@@ -247,6 +249,11 @@ func main() {
 	case "version":
 		fmt.Printf("govm %s\n", Version)
 		os.Exit(0)
+	case "config":
+		if err := ensureDirExists(versionsDir); err != nil {
+			fmt.Printf("Error creating config directory: %v\n", err)
+		}
+		ensureDirExists(versionsDir)
 	case "list":
 		listVersions()
 	case "use":
@@ -268,6 +275,7 @@ func main() {
 		}
 		uninstallVersion(os.Args[2])
 	default:
-		fmt.Println("Unknown command:", command)
+		colors.SetColor(color.FgRed, "Unknown command: %s\n", command)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
La versión 0.0.2 se agregaron las siguientes

- Add: [6f5f8bc](https://github.com/JuanPerdomo00/gomv/commit/6f5f8bc25ac835842859513a599e98d9d014b899) LICENSE MIT
- Add: [aaadd6](https://github.com/JuanPerdomo00/gomv/commit/aaadd6cc1fe4c98561856bd2c489d8b1867740b8) Package colors lib
- Add: [a9a10a](https://github.com/JuanPerdomo00/gomv/commit/a9a10a3f3eac1d046d3511d2b3372fa8fec464ff) Update version, y se agregaron mejoras en la stdout de `help` tambien se agrego el comando `config` ya que no permitia crear la carpeta cuando se ejecutaba por primera vez. Fix
- Add: [d6e802](https://github.com/JuanPerdomo00/gomv/commit/d6e802bfa9afec81f4f4782a06f0afb2f8c6b097) Package Color mod
- Update: [41d1a4](https://github.com/JuanPerdomo00/gomv/commit/41d1a4bf763c581185c3219eb7469ee9caa779e2) Se agrego el `-o govm` para que el binario se compile con ese nombre, tambien se agrego el funcionamiento de el comando `config`
